### PR TITLE
Fix for wait_main_hart

### DIFF
--- a/src/platform/mpfs_hal/startup_gcc/mss_entry.S
+++ b/src/platform/mpfs_hal/startup_gcc/mss_entry.S
@@ -240,7 +240,7 @@ _start:
     li a3, HLS_MAIN_HART_STARTED
     la a1, (__stack_top_h0$ - HLS_DEBUG_AREA_SIZE)
 .wait_main_hart:
-    LOAD a2, 0(a1)
+    LWU a2, 0(a1)
     bne a3, a2, .wait_main_hart
     # Flag we are here to the main hart
     li a1, HLS_OTHER_HART_IN_WFI


### PR DESCRIPTION
The LOAD instruction in the wait_main_hart should be a LWU instruction. 
The goal of this function is to read the hls->in_wfi_indicator data (which is 32-bit) and compare it to the value of HLS_MAIN_HART_STARTED (also 32-bit).
LWU is for loading a 32-bit data, which is the case here. The LOAD instruction is for 64-bit data.
Using LOAD can cause issues when the 32-bit data right next to in_wfi_indicator is not equal to 0.
(The other solution is to make in_wfi_indicator 64-bit)