### PR TITLE
mpfs_hal: fix hw_platform.h header inclusion after d1d7a29d3ccabc4a23…

### DIFF
--- a/src/platform/mpfs_hal/mss_hal.h
+++ b/src/platform/mpfs_hal/mss_hal.h
@@ -47,7 +47,7 @@ typedef long            ssize_t;
 #include "common/atomic.h"
 #include "common/bits.h"
 #include "common/encoding.h"
-#include "soc_config/hw_platform.h"
+#include "fpga_config/hw_platform.h"
 #include "common/nwc/mss_ddr.h"
 #include "common/mss_clint.h"
 #include "common/mss_h2f.h"


### PR DESCRIPTION
…02bae1534850728668efaa